### PR TITLE
Add a comment about a bug in a unit test

### DIFF
--- a/chronological-issues-from-video.md
+++ b/chronological-issues-from-video.md
@@ -56,3 +56,8 @@ Or whatever version your `@chainlink` and `@openzeppelin` contracts need. For ex
   - In the video, we use events exclusivly to test our contracts, however, we could have also used `tx.return_value` to get the return value of a function. 
   - However, it's still best practice to learn how to use events, especially when updating mappings!
 
+- [8:10:20ish](https://youtu.be/M576WGiDBdQ?t=29423)
+  - In the video, `starting_balance_of_account` and `balance_of_lottery` are retrieved AFTER `lottery.endLottery()`
+  - For correctness those 2 statements should be run BEFORE `lottery.endLottery()` 
+  - The tests pass because `starting_balance_of_account == account.balance()` (L81) and `lottery.balance()` is already 0
+  - This is a subtle bug in the test, which also showcases a problem with tests - we have no one to test the tests ;) Still, having tests is better than not having them, just don't put all your assurances into them


### PR DESCRIPTION

(note: issue description is in the commit)

Added some prints to the original code, and ran with `brownie test -s -k test_picks_winner_correctly`

output is
```
tests/test_lottery_unit.py::test_picks_winner_correctly RUNNING
lottery deployed
funded 0x6951b5Bd815043E3F842c1b026b0Fa888Cc2DD85 with 1e+17 LINK
original balance in account 100050000000000000000
original balance in lottery 0
final balance in account 100050000000000000000
final balance in lottery 0
tests/test_lottery_unit.py::test_picks_winner_correctly PASSED
```

After fixing the test, reran and output is
```
tests/test_lottery_unit.py::test_picks_winner_correctly RUNNING
lottery deployed
funded 0x6951b5Bd815043E3F842c1b026b0Fa888Cc2DD85 with 1e+17 LINK
original balance in account 99975000000000000000
original balance in lottery 75000000000000000
final balance in account 100050000000000000000
final balance in lottery 0
tests/test_lottery_unit.py::test_picks_winner_correctly PASSED
```