### PR TITLE
Adds additional support to common issue.

### DIFF
--- a/chronological-issues-from-video.md
+++ b/chronological-issues-from-video.md
@@ -73,7 +73,7 @@ transaction = SimpleStorage.constructor().buildTransaction(
 
     ![image](https://user-images.githubusercontent.com/2119741/147293025-4dec848b-747b-4da7-9009-3f9174198b54.png)
 - [4:34:25](https://youtu.be/M576WGiDBdQ?t=16465) Command `$ brownie run scripts/deploy.py`
-  - If you encounter an issue with ports, you can update the port to 8545 under settings -> Server
+  - If you encounter an issue with ports, you can update the port to 8545 under Settings -> Server. This is the standard port that will be connected to by the `$ brownie run <path>` command.
 ## Lesson 7
 - [8:06:54ish](https://youtu.be/M576WGiDBdQ?t=29214)
   - In the video, we use events exclusivly to test our contracts, however, we could have also used `tx.return_value` to get the return value of a function. 

--- a/chronological-issues-from-video.md
+++ b/chronological-issues-from-video.md
@@ -72,7 +72,8 @@ transaction = SimpleStorage.constructor().buildTransaction(
   `Editor > Bracket Pair Colorization:` **Enabled**
 
     ![image](https://user-images.githubusercontent.com/2119741/147293025-4dec848b-747b-4da7-9009-3f9174198b54.png)
-
+- [4:34:25](https://youtu.be/M576WGiDBdQ?t=16465) Command `$ brownie run scripts/deploy.py`
+  - If you encounter an issue with ports, you can update the port to 8545 under settings -> Server
 ## Lesson 7
 - [8:06:54ish](https://youtu.be/M576WGiDBdQ?t=29214)
   - In the video, we use events exclusivly to test our contracts, however, we could have also used `tx.return_value` to get the return value of a function. 


### PR DESCRIPTION
- As can be seen on [Stackoverflow this](https://stackoverflow.com/questions/70370224/problems-using-ganache-cli-command) is a common issue encountered by people working through this tutorial. 
- The recommended advice in this PR more directly deals with the issue of default port configurations being mismatched between ganache and what is expected by brownie.
- We do this by updating the port in ganache to the default port looked for by brownie run.