### PR TITLE
ganache-cli deprecated makes yarn unnecessary use npm install ganache instead

### DIFF
--- a/chronological-issues-from-video.md
+++ b/chronological-issues-from-video.md
@@ -73,6 +73,14 @@ transaction = SimpleStorage.constructor().buildTransaction(
 
     ![image](https://user-images.githubusercontent.com/2119741/147293025-4dec848b-747b-4da7-9009-3f9174198b54.png)
 
+- [4:19:40](https://youtu.be/M576WGiDBdQ?t=15580) Installing ganache-cli with yarn
+  - ganache-cli is deprecated
+  - visit [GitHub Ganach repo](https://github.com/trufflesuite/ganache/releases/tag/v7.0.0) for details
+  - Yarn installation is no longer necessary. Installation is now via npm 
+  - `install ganache --global`
+  - Usage is simply: `ganache` 
+  - Visit [https://www.npmjs.com/package/ganache](https://www.npmjs.com/package/ganache) for more information.
+
 ## Lesson 7
 - [8:06:54ish](https://youtu.be/M576WGiDBdQ?t=29214)
   - In the video, we use events exclusivly to test our contracts, however, we could have also used `tx.return_value` to get the return value of a function. 


### PR DESCRIPTION
Makes life easier especially in combination of venv, nodeenv and ganache.

I recently [added an article to the discussion group](https://github.com/smartcontractkit/full-blockchain-solidity-course-py/discussions/938) about using node npm in conjunction with python venv. This change simplifies the setup because yarn is no longer needed.
